### PR TITLE
feat: GraphQL resolverでusecaseからinputの型をインポート

### DIFF
--- a/graphql/src/server.ts
+++ b/graphql/src/server.ts
@@ -4,6 +4,10 @@ import { deleteBookmarkUseCase } from "./application/bookmarks/DeleteBookmarkUse
 import { fetchBookmarkByIdUseCase } from "./application/bookmarks/FetchBookmarkByIdUseCase";
 import { fetchBookmarksUseCase } from "./application/bookmarks/FetchBookmarksUseCase";
 import { updateBookmarkUseCase } from "./application/bookmarks/UpdateBookmarkUseCase";
+import type {
+  CreateBookmarkInput,
+  UpdateBookmarkInput,
+} from "./infrastructure/domain/Bookmark";
 
 export const server = {
   Query: {
@@ -12,15 +16,10 @@ export const server = {
     bookmark: async (id: string) => await fetchBookmarkByIdUseCase(id),
   },
   Mutation: {
-    createBookmark: async (input: {
-      title: string;
-      url: string;
-      description?: string;
-    }) => await createBookmarkUseCase(input),
-    updateBookmark: async (
-      id: string,
-      input: { title?: string; url?: string; description?: string },
-    ) => await updateBookmarkUseCase(id, input),
+    createBookmark: async (input: CreateBookmarkInput) =>
+      await createBookmarkUseCase(input),
+    updateBookmark: async (id: string, input: UpdateBookmarkInput) =>
+      await updateBookmarkUseCase(id, input),
     deleteBookmark: async (id: string) => await deleteBookmarkUseCase(id),
   },
 };


### PR DESCRIPTION
## 概要

- GraphQL resolverで利用するinputの型定義を、inline定義からusecase層の型をインポートする形に変更しました。これにより型の一貫性を保ち、型安全性を向上させています。

## テスト計画

- [ ] 型チェックが正常に通ることを確認
- [ ] リンターチェックが正常に通ることを確認
- [ ] 既存のテストが正常に動作することを確認
- [ ] GraphQL resolverのcreateBookmarkとupdateBookmarkが適切な型を使用していることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #113