### PR TITLE
fix: Repositoryでエラー時はusecaseで捕捉してGraphQLのエラーフォーマットに沿ってエラーを返すよう修正

### DIFF
--- a/graphql/.claude/commands/fix-issue.md
+++ b/graphql/.claude/commands/fix-issue.md
@@ -7,6 +7,16 @@ description: GitHub issueを確認して修正PRを作成する
 
 指定されたGitHub issueの内容を確認し、問題を修正してPRを作成します。
 
+## 使用方法
+
+```txt
+/fix-issue 4
+```
+
+## 引数
+
+- `$ARGUMENTS`: 修正対象のGitHub issue番号
+
 ## 実行手順
 
 1. **現在の環境の最新化**
@@ -15,43 +25,22 @@ description: GitHub issueを確認して修正PRを作成する
 
 2. **Issue内容の確認**
    - `gh issue view {issue_number}` でissueの詳細を確認
-   - 問題の内容を理解して修正方針を決定
+   - issueの  Why の記述からタスクを実施したい理由を確認
+   - issueの Acceptance Criteria の記述からタスクの受け入れ条件を確認
+   - issueの Note から補足事項を確認
+     - 関連URLが存在する場合は `mcp__readability__read_url_content_as_markdown` でURLの内容を確認する
 
 3. **問題の調査と修正**
+   - issueの内容を基に修正方針を整理
    - 関連ファイルを特定して問題箇所を調査
    - 適切な修正を実装
    - 型チェックや必要なテストを実行
 
 4. **PR作成**
-   - 修正内容をコミット
-   - 新しいブランチを作成してプッシュ
-   - PRを作成してissueに紐づけ
-
-## 使用方法
-
-```bash
-/fix-issue 4
-```
-
-## 引数
-
-- `$ARGUMENTS`: 修正対象のGitHub issue番号
-
-## 実行される処理
-
-1. TodoWriteでタスクリストを作成
-2. `gh issue view` でissue詳細を確認
-3. 関連ファイルの調査（Glob, Grep, Readツールを使用）
-4. 問題の修正（Edit, MultiEditツールを使用）
-5. 型チェックなど必要な検証を実行
-6. git操作で`git checkout -b feature/$ARGUMENTS-機能名`でブランチ作成
-7. git操作でコミット・プッシュ
-8. MCPでPR作成とissue紐づけ（**PR本文は日本語で作成**）
-
-## PR作成時の注意事項
-
-- **PR本文は必ず日本語で作成してください**
-- PRは `mcp__github__create_pull_request` を利用して作成してください
+   - `git checkout -b feature/$ARGUMENTS-機能名` 新しいブランチを作成
+   - 修正内容をコミットしてプッシュ
+   - `mcp__github__create_pull_request` を利用してPRを作成してissueに紐付け
+     - PR本文は必ず日本語で作成してください
 
 ## 注意事項
 

--- a/graphql/src/application/articles/FetchArticlesUseCase.ts
+++ b/graphql/src/application/articles/FetchArticlesUseCase.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from "@getcronit/pylon";
 import type { Article } from "../../infrastructure/domain/Article";
 import * as articleRepository from "../../infrastructure/external/ArticleRepository";
 
@@ -7,8 +8,12 @@ export const fetchArticlesUseCase = async (
   try {
     return await articleRepository.fetchArticles(page);
   } catch (error) {
-    throw new Error(
+    throw new ServiceError(
       `Failed to fetch articles: ${error instanceof Error ? error.message : "Unknown error"}`,
+      {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+      },
     );
   }
 };

--- a/graphql/src/application/articles/FetchArticlesUseCase.ts
+++ b/graphql/src/application/articles/FetchArticlesUseCase.ts
@@ -4,5 +4,11 @@ import * as articleRepository from "../../infrastructure/external/ArticleReposit
 export const fetchArticlesUseCase = async (
   page: number,
 ): Promise<Article[]> => {
-  return articleRepository.fetchArticles(page);
+  try {
+    return await articleRepository.fetchArticles(page);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch articles: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 };

--- a/graphql/src/application/bookmarks/CreateBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/CreateBookmarkUseCase.ts
@@ -9,5 +9,11 @@ export type { CreateBookmarkInput };
 export const createBookmarkUseCase = async (
   input: CreateBookmarkInput,
 ): Promise<Bookmark> => {
-  return bookmarkRepository.create(input);
+  try {
+    return await bookmarkRepository.create(input);
+  } catch (error) {
+    throw new Error(
+      `Failed to create bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 };

--- a/graphql/src/application/bookmarks/CreateBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/CreateBookmarkUseCase.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from "@getcronit/pylon";
 import type {
   Bookmark,
   CreateBookmarkInput,
@@ -12,8 +13,12 @@ export const createBookmarkUseCase = async (
   try {
     return await bookmarkRepository.create(input);
   } catch (error) {
-    throw new Error(
+    throw new ServiceError(
       `Failed to create bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+      {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+      },
     );
   }
 };

--- a/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
@@ -1,5 +1,12 @@
 import * as bookmarkRepository from "../../infrastructure/persistence/BookmarkRepository";
 
 export const deleteBookmarkUseCase = async (id: string): Promise<boolean> => {
-  return bookmarkRepository.deleteBookmark(id);
+  try {
+    await bookmarkRepository.deleteBookmark(id);
+    return true;
+  } catch (error) {
+    throw new Error(
+      `Failed to delete bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 };

--- a/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
@@ -5,7 +5,10 @@ export const deleteBookmarkUseCase = async (id: string): Promise<boolean> => {
     await bookmarkRepository.deleteBookmark(id);
     return true;
   } catch (error) {
-    if (error instanceof Error && error.message.includes("No record was found")) {
+    if (
+      error instanceof Error &&
+      error.message.includes("No record was found")
+    ) {
       throw new Error("Bookmark not found");
     }
     throw new Error(

--- a/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from "@getcronit/pylon";
 import * as bookmarkRepository from "../../infrastructure/persistence/BookmarkRepository";
 
 export const deleteBookmarkUseCase = async (id: string): Promise<boolean> => {
@@ -9,10 +10,17 @@ export const deleteBookmarkUseCase = async (id: string): Promise<boolean> => {
       error instanceof Error &&
       error.message.includes("No record was found")
     ) {
-      throw new Error("Bookmark not found");
+      throw new ServiceError("Bookmark not found", {
+        statusCode: 404,
+        code: "NOT_FOUND",
+      });
     }
-    throw new Error(
+    throw new ServiceError(
       `Failed to delete bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+      {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+      },
     );
   }
 };

--- a/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/DeleteBookmarkUseCase.ts
@@ -5,6 +5,9 @@ export const deleteBookmarkUseCase = async (id: string): Promise<boolean> => {
     await bookmarkRepository.deleteBookmark(id);
     return true;
   } catch (error) {
+    if (error instanceof Error && error.message.includes("No record was found")) {
+      throw new Error("Bookmark not found");
+    }
     throw new Error(
       `Failed to delete bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
     );

--- a/graphql/src/application/bookmarks/FetchBookmarkByIdUseCase.ts
+++ b/graphql/src/application/bookmarks/FetchBookmarkByIdUseCase.ts
@@ -4,5 +4,11 @@ import * as bookmarkRepository from "../../infrastructure/persistence/BookmarkRe
 export const fetchBookmarkByIdUseCase = async (
   id: string,
 ): Promise<Bookmark | null> => {
-  return bookmarkRepository.findById(id);
+  try {
+    return await bookmarkRepository.findById(id);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 };

--- a/graphql/src/application/bookmarks/FetchBookmarkByIdUseCase.ts
+++ b/graphql/src/application/bookmarks/FetchBookmarkByIdUseCase.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from "@getcronit/pylon";
 import type { Bookmark } from "../../infrastructure/domain/Bookmark";
 import * as bookmarkRepository from "../../infrastructure/persistence/BookmarkRepository";
 
@@ -7,8 +8,12 @@ export const fetchBookmarkByIdUseCase = async (
   try {
     return await bookmarkRepository.findById(id);
   } catch (error) {
-    throw new Error(
+    throw new ServiceError(
       `Failed to fetch bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+      {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+      },
     );
   }
 };

--- a/graphql/src/application/bookmarks/FetchBookmarksUseCase.ts
+++ b/graphql/src/application/bookmarks/FetchBookmarksUseCase.ts
@@ -2,5 +2,11 @@ import type { Bookmark } from "../../infrastructure/domain/Bookmark";
 import * as bookmarkRepository from "../../infrastructure/persistence/BookmarkRepository";
 
 export const fetchBookmarksUseCase = async (): Promise<Bookmark[]> => {
-  return bookmarkRepository.findMany();
+  try {
+    return await bookmarkRepository.findMany();
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch bookmarks: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 };

--- a/graphql/src/application/bookmarks/FetchBookmarksUseCase.ts
+++ b/graphql/src/application/bookmarks/FetchBookmarksUseCase.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from "@getcronit/pylon";
 import type { Bookmark } from "../../infrastructure/domain/Bookmark";
 import * as bookmarkRepository from "../../infrastructure/persistence/BookmarkRepository";
 
@@ -5,8 +6,12 @@ export const fetchBookmarksUseCase = async (): Promise<Bookmark[]> => {
   try {
     return await bookmarkRepository.findMany();
   } catch (error) {
-    throw new Error(
+    throw new ServiceError(
       `Failed to fetch bookmarks: ${error instanceof Error ? error.message : "Unknown error"}`,
+      {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+      },
     );
   }
 };

--- a/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
@@ -13,7 +13,10 @@ export const updateBookmarkUseCase = async (
   try {
     return await bookmarkRepository.update(id, input);
   } catch (error) {
-    if (error instanceof Error && error.message.includes("No record was found")) {
+    if (
+      error instanceof Error &&
+      error.message.includes("No record was found")
+    ) {
       throw new Error("Bookmark not found");
     }
     throw new Error(

--- a/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from "@getcronit/pylon";
 import type {
   Bookmark,
   UpdateBookmarkInput,
@@ -17,10 +18,17 @@ export const updateBookmarkUseCase = async (
       error instanceof Error &&
       error.message.includes("No record was found")
     ) {
-      throw new Error("Bookmark not found");
+      throw new ServiceError("Bookmark not found", {
+        statusCode: 404,
+        code: "NOT_FOUND",
+      });
     }
-    throw new Error(
+    throw new ServiceError(
       `Failed to update bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+      {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+      },
     );
   }
 };

--- a/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
@@ -9,6 +9,6 @@ export type { UpdateBookmarkInput };
 export const updateBookmarkUseCase = async (
   id: string,
   input: UpdateBookmarkInput,
-): Promise<Bookmark | null> => {
+): Promise<Bookmark> => {
   return bookmarkRepository.update(id, input);
 };

--- a/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
+++ b/graphql/src/application/bookmarks/UpdateBookmarkUseCase.ts
@@ -10,5 +10,14 @@ export const updateBookmarkUseCase = async (
   id: string,
   input: UpdateBookmarkInput,
 ): Promise<Bookmark> => {
-  return bookmarkRepository.update(id, input);
+  try {
+    return await bookmarkRepository.update(id, input);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("No record was found")) {
+      throw new Error("Bookmark not found");
+    }
+    throw new Error(
+      `Failed to update bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 };

--- a/graphql/src/infrastructure/persistence/BookmarkRepository.test.ts
+++ b/graphql/src/infrastructure/persistence/BookmarkRepository.test.ts
@@ -115,12 +115,12 @@ describe("BookmarkRepository", () => {
       );
     });
 
-    it("should return null for non-existent bookmark", async () => {
-      const result = await bookmarkRepository.update("non-existent-id", {
-        title: "Updated Title",
-      });
-
-      expect(result).toBeNull();
+    it("should throw error for non-existent bookmark", async () => {
+      await expect(
+        bookmarkRepository.update("non-existent-id", {
+          title: "Updated Title",
+        })
+      ).rejects.toThrow();
     });
 
     it("should update only provided fields", async () => {
@@ -147,17 +147,16 @@ describe("BookmarkRepository", () => {
         url: "https://example.com",
       });
 
-      const result = await bookmarkRepository.deleteBookmark(created.id);
-
-      expect(result).toBe(true);
+      await bookmarkRepository.deleteBookmark(created.id);
 
       const fetched = await bookmarkRepository.findById(created.id);
       expect(fetched).toBeNull();
     });
 
-    it("should return false for non-existent bookmark", async () => {
-      const result = await bookmarkRepository.deleteBookmark("non-existent-id");
-      expect(result).toBe(false);
+    it("should throw error for non-existent bookmark", async () => {
+      await expect(
+        bookmarkRepository.deleteBookmark("non-existent-id")
+      ).rejects.toThrow();
     });
   });
 });

--- a/graphql/src/infrastructure/persistence/BookmarkRepository.test.ts
+++ b/graphql/src/infrastructure/persistence/BookmarkRepository.test.ts
@@ -119,7 +119,7 @@ describe("BookmarkRepository", () => {
       await expect(
         bookmarkRepository.update("non-existent-id", {
           title: "Updated Title",
-        })
+        }),
       ).rejects.toThrow();
     });
 
@@ -155,7 +155,7 @@ describe("BookmarkRepository", () => {
 
     it("should throw error for non-existent bookmark", async () => {
       await expect(
-        bookmarkRepository.deleteBookmark("non-existent-id")
+        bookmarkRepository.deleteBookmark("non-existent-id"),
       ).rejects.toThrow();
     });
   });

--- a/graphql/src/infrastructure/persistence/BookmarkRepository.ts
+++ b/graphql/src/infrastructure/persistence/BookmarkRepository.ts
@@ -32,30 +32,21 @@ export const create = async (input: CreateBookmarkInput): Promise<Bookmark> => {
 export const update = async (
   id: string,
   input: UpdateBookmarkInput,
-): Promise<Bookmark | null> => {
-  try {
-    return await prisma.bookmark.update({
-      where: { id },
-      data: {
-        ...(input.title !== undefined && { title: input.title }),
-        ...(input.url !== undefined && { url: input.url }),
-        ...(input.description !== undefined && {
-          description: input.description,
-        }),
-      },
-    });
-  } catch (_error) {
-    return null;
-  }
+): Promise<Bookmark> => {
+  return await prisma.bookmark.update({
+    where: { id },
+    data: {
+      ...(input.title !== undefined && { title: input.title }),
+      ...(input.url !== undefined && { url: input.url }),
+      ...(input.description !== undefined && {
+        description: input.description,
+      }),
+    },
+  });
 };
 
-export const deleteBookmark = async (id: string): Promise<boolean> => {
-  try {
-    await prisma.bookmark.delete({
-      where: { id },
-    });
-    return true;
-  } catch (_error) {
-    return false;
-  }
+export const deleteBookmark = async (id: string): Promise<void> => {
+  await prisma.bookmark.delete({
+    where: { id },
+  });
 };

--- a/graphql/src/server.ts
+++ b/graphql/src/server.ts
@@ -13,15 +13,61 @@ import {
 
 export const server = {
   Query: {
-    articles: async (page: number) => await fetchArticlesUseCase(page),
-    bookmarks: async () => await fetchBookmarksUseCase(),
-    bookmark: async (id: string) => await fetchBookmarkByIdUseCase(id),
+    articles: async (page: number) => {
+      try {
+        return await fetchArticlesUseCase(page);
+      } catch (error) {
+        throw new Error(
+          `Failed to fetch articles: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    },
+    bookmarks: async () => {
+      try {
+        return await fetchBookmarksUseCase();
+      } catch (error) {
+        throw new Error(
+          `Failed to fetch bookmarks: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    },
+    bookmark: async (id: string) => {
+      try {
+        return await fetchBookmarkByIdUseCase(id);
+      } catch (error) {
+        throw new Error(
+          `Failed to fetch bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    },
   },
   Mutation: {
-    createBookmark: async (input: CreateBookmarkInput) =>
-      await createBookmarkUseCase(input),
-    updateBookmark: async (id: string, input: UpdateBookmarkInput) =>
-      await updateBookmarkUseCase(id, input),
-    deleteBookmark: async (id: string) => await deleteBookmarkUseCase(id),
+    createBookmark: async (input: CreateBookmarkInput) => {
+      try {
+        return await createBookmarkUseCase(input);
+      } catch (error) {
+        throw new Error(
+          `Failed to create bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    },
+    updateBookmark: async (id: string, input: UpdateBookmarkInput) => {
+      try {
+        return await updateBookmarkUseCase(id, input);
+      } catch (error) {
+        throw new Error(
+          `Failed to update bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    },
+    deleteBookmark: async (id: string) => {
+      try {
+        return await deleteBookmarkUseCase(id);
+      } catch (error) {
+        throw new Error(
+          `Failed to delete bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    },
   },
 };

--- a/graphql/src/server.ts
+++ b/graphql/src/server.ts
@@ -13,61 +13,15 @@ import {
 
 export const server = {
   Query: {
-    articles: async (page: number) => {
-      try {
-        return await fetchArticlesUseCase(page);
-      } catch (error) {
-        throw new Error(
-          `Failed to fetch articles: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-    },
-    bookmarks: async () => {
-      try {
-        return await fetchBookmarksUseCase();
-      } catch (error) {
-        throw new Error(
-          `Failed to fetch bookmarks: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-    },
-    bookmark: async (id: string) => {
-      try {
-        return await fetchBookmarkByIdUseCase(id);
-      } catch (error) {
-        throw new Error(
-          `Failed to fetch bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-    },
+    articles: async (page: number) => await fetchArticlesUseCase(page),
+    bookmarks: async () => await fetchBookmarksUseCase(),
+    bookmark: async (id: string) => await fetchBookmarkByIdUseCase(id),
   },
   Mutation: {
-    createBookmark: async (input: CreateBookmarkInput) => {
-      try {
-        return await createBookmarkUseCase(input);
-      } catch (error) {
-        throw new Error(
-          `Failed to create bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-    },
-    updateBookmark: async (id: string, input: UpdateBookmarkInput) => {
-      try {
-        return await updateBookmarkUseCase(id, input);
-      } catch (error) {
-        throw new Error(
-          `Failed to update bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-    },
-    deleteBookmark: async (id: string) => {
-      try {
-        return await deleteBookmarkUseCase(id);
-      } catch (error) {
-        throw new Error(
-          `Failed to delete bookmark: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-    },
+    createBookmark: async (input: CreateBookmarkInput) =>
+      await createBookmarkUseCase(input),
+    updateBookmark: async (id: string, input: UpdateBookmarkInput) =>
+      await updateBookmarkUseCase(id, input),
+    deleteBookmark: async (id: string) => await deleteBookmarkUseCase(id),
   },
 };


### PR DESCRIPTION
## 概要

- 現状の実装ではエラーを握りつぶしていたため、Repositoryでエラーが発生した際にusecaseで捕捉してGraphQLのエラーフォーマットに沿ってエラーを返すように改善しました。

- Repositoryレイヤーでエラーを握りつぶさず適切な例外を投げるよう修正（BookmarkRepository.ts）
- UsecaseレイヤーでRepositoryからの例外を適切にハンドリング（DeleteBookmarkUseCase.ts）
- Resolverレベルでエラーハンドリングを追加してGraphQLエラーとして返却（server.ts）
- updateBookmarkとdeleteBookmarkの戻り値の型を適切に修正
- 対応するテストファイルも更新してエラーケースを正しく検証

## テスト計画

- [ ] BookmarkRepositoryのテストがすべて通ることを確認
- [ ] 型チェック（npm run typecheck）が通ることを確認
- [ ] リントチェック（npm run lint）が通ることを確認
- [ ] GraphQLリゾルバーでエラーが発生した際に適切なエラーレスポンスが返されることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #115