### PR TITLE
lefthookのpre-pushでstagedファイルが存在する場合pushを失敗させる機能を追加

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,23 @@
 pre-push:
   parallel: true
   commands:
+    check-staged-files:
+      run: |
+        if git diff --cached --exit-code > /dev/null; then
+          echo "✅ No staged files found. Push is allowed."
+        else
+          echo "❌ Error: There are staged files that haven't been committed."
+          echo "This usually happens when pre-commit hooks format files but the changes aren't committed."
+          echo ""
+          echo "Staged files:"
+          git diff --cached --name-only
+          echo ""
+          echo "Please commit these changes before pushing:"
+          echo "  git add ."
+          echo "  git commit --amend --no-edit"
+          echo "  # or create a new commit"
+          exit 1
+        fi
     mobile-tests:
       glob: "mobile/**"
       run: cd mobile && pnpm jest --changedSince main


### PR DESCRIPTION
## 概要

- pre-commitでフォーマットされたファイルのコミット漏れを検知する仕組みを実装しました。

具体的には、lefthook.ymlのpre-pushフックに`check-staged-files`コマンドを追加し、Gitのステージングエリアにファイルが存在する場合はpushを失敗させ、適切なエラーメッセージと解決方法を表示するようにしました。

## テスト計画

- [ ] lefthookのpre-pushフックが正常に動作することを確認
- [ ] stagedファイルが存在しない場合、pushが成功することを確認
- [ ] stagedファイルが存在する場合、pushが失敗し適切なエラーメッセージが表示されることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #122