### PR TITLE
feat: vitest setupでPrisma DBクリア処理を追加

### DIFF
--- a/graphql/src/libs/test/vitest.setup.ts
+++ b/graphql/src/libs/test/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll } from "vitest";
+import { prisma } from "../prisma/client";
 import { mockServer } from "./mockServer";
 
 beforeAll(async () => {
@@ -7,8 +8,10 @@ beforeAll(async () => {
 
 afterEach(async () => {
   mockServer.resetHandlers();
+  await prisma.bookmark.deleteMany();
 });
 
-afterAll(() => {
+afterAll(async () => {
   mockServer.close();
+  await prisma.$disconnect();
 });


### PR DESCRIPTION
## 概要

- vitest setupにPrisma データベースのクリア処理を追加し、テスト間でのデータ競合を防ぐためのセットアップを一元化しました。

## テスト計画

- [ ] vitest setupでDBクリア処理が動作することを確認
- [ ] 既存テストが全て成功することを確認
- [ ] 各テストでのDBクリア処理の重複が解消されることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #124