### PR TITLE
feat: react-error-boundaryを使用したエラーハンドリングを追加

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -38,6 +38,7 @@
     "graphql": "^16.11.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.62.0",
     "react-native": "0.79.5",
     "react-native-paper": "^5.14.5",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      react-error-boundary:
+        specifier: ^6.0.0
+        version: 6.0.0(react@19.0.0)
       react-hook-form:
         specifier: ^7.62.0
         version: 7.62.0(react@19.0.0)
@@ -6201,6 +6204,11 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-error-boundary@6.0.0:
+    resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -15674,6 +15682,11 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-error-boundary@6.0.0(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.28.2
+      react: 19.0.0
 
   react-fast-compare@3.2.2: {}
 

--- a/mobile/src/components/error-boundary/ErrorFallback.tsx
+++ b/mobile/src/components/error-boundary/ErrorFallback.tsx
@@ -1,0 +1,81 @@
+import type { FC } from "react";
+import { StyleSheet, View } from "react-native";
+import { Button, Card, Text } from "react-native-paper";
+
+export interface ErrorFallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+export const ErrorFallback: FC<ErrorFallbackProps> = ({
+  error,
+  resetErrorBoundary,
+}) => {
+  return (
+    <View style={styles.container}>
+      <Card style={styles.card}>
+        <Card.Content>
+          <Text variant="headlineMedium" style={styles.title}>
+            エラーが発生しました
+          </Text>
+          <Text variant="bodyMedium" style={styles.description}>
+            申し訳ございませんが、アプリケーションでエラーが発生しました。
+            以下のボタンを押して再試行してください。
+          </Text>
+          {__DEV__ && (
+            <View style={styles.errorDetails}>
+              <Text variant="labelLarge" style={styles.errorTitle}>
+                エラー詳細（開発モードのみ）:
+              </Text>
+              <Text variant="bodySmall" style={styles.errorMessage}>
+                {error.message}
+              </Text>
+            </View>
+          )}
+        </Card.Content>
+        <Card.Actions>
+          <Button mode="contained" onPress={resetErrorBoundary}>
+            再試行
+          </Button>
+        </Card.Actions>
+      </Card>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+    backgroundColor: "#f5f5f5",
+  },
+  card: {
+    maxWidth: 400,
+    width: "100%",
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 16,
+    color: "#d32f2f",
+  },
+  description: {
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  errorDetails: {
+    marginTop: 16,
+    padding: 12,
+    backgroundColor: "#ffebee",
+    borderRadius: 8,
+  },
+  errorTitle: {
+    marginBottom: 8,
+    fontWeight: "bold",
+  },
+  errorMessage: {
+    fontFamily: "monospace",
+    color: "#d32f2f",
+  },
+});

--- a/mobile/src/libs/AppProvider.tsx
+++ b/mobile/src/libs/AppProvider.tsx
@@ -1,11 +1,26 @@
-import type { FC, PropsWithChildren } from "react";
+import type { ErrorInfo, FC, PropsWithChildren } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { ErrorFallback } from "@/components/error-boundary/ErrorFallback";
 import { AppApolloProvider } from "./graphql/AppApolloProvider";
 import { PaperProvider } from "./react-native-paper/PaperProvider";
 
+const handleError = (error: Error, errorInfo: ErrorInfo) => {
+  console.error("Error caught by ErrorBoundary:", error, errorInfo);
+};
+
 export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <AppApolloProvider>
-      <PaperProvider>{children}</PaperProvider>
-    </AppApolloProvider>
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onError={handleError}
+      onReset={() => {
+        // アプリの状態をリセットする場合はここに実装
+        console.log("ErrorBoundary reset");
+      }}
+    >
+      <AppApolloProvider>
+        <PaperProvider>{children}</PaperProvider>
+      </AppApolloProvider>
+    </ErrorBoundary>
   );
 };


### PR DESCRIPTION
## 概要

- GraphQLエラー時の適切なハンドリングを実現するため、react-error-boundaryライブラリを使用したエラーバウンダリを実装しました。

## テスト計画

- [ ] アプリケーション起動時にエラーバウンダリが正常に動作することを確認
- [ ] エラー発生時に適切なフォールバックUIが表示されることを確認
- [ ] エラー詳細が開発モードでのみ表示されることを確認
- [ ] 再試行ボタンが正常に動作することを確認

## 補足事項

- GraphQLエラーやコンポーネントエラーが発生した際に、アプリケーションがクラッシュせずに適切なエラーメッセージを表示します
- 開発環境ではエラーの詳細情報も表示されるため、デバッグが容易になります

Fixes #152