### PR TITLE
feat: reactをdependabot対象外に追加

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -58,6 +58,7 @@ updates:
       - dependency-name: "expo-status-bar"
       - dependency-name: "expo-system-ui"
       - dependency-name: "expo-sqlite"
+      - dependency-name: "react"
       - dependency-name: "react-native"
       - dependency-name: "react-native-gesture-handler"
       - dependency-name: "react-native-get-random-values"


### PR DESCRIPTION
## 概要

- expo-linking、expo-status-barは既に対象外になっているが、reactもExpoでバージョンが指定されているため対象外に追加しました。これによりExpoのバージョンアップ時に一括で更新できるようになります。

## テスト計画

- [ ] dependabot.yamlの設定が正しく反映されていることを確認
- [ ] reactがdependabotの自動更新対象から除外されていることを確認
- [ ] 既存のexpo-linking、expo-status-barも引き続き対象外になっていることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #154