### PR TITLE
feat: dependabotのnpm設定をルートディレクトリに統合

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,24 +23,6 @@ updates:
       timezone: Asia/Tokyo
     cooldown:
       default-days: 3
-  - package-ecosystem: npm
-    directory: /graphql
-    schedule:
-      interval: weekly
-      day: friday
-      time: "08:00"
-      timezone: Asia/Tokyo
-    cooldown:
-      default-days: 3
-  - package-ecosystem: npm
-    directory: /mobile
-    schedule:
-      interval: weekly
-      day: sunday
-      time: "08:00"
-      timezone: Asia/Tokyo
-    cooldown:
-      default-days: 3
     ignore:
       # fix_expo_version.yml でバージョンの修正をしているため対象外にする
       # expo のメジャーバージョンアップ時には手動で修正する


### PR DESCRIPTION
## 概要

- dependabotの設定でmobileとgraphqlディレクトリの個別設定をルートディレクトリに統合しました。これにより、ディレクトリ個別設定による設定競合の問題が解決されます。

## テスト計画

- [ ] dependabot.yamlファイルの構文が正しいことを確認
- [ ] GitHubでdependabotの設定が正しく認識されることを確認
- [ ] 以前のignore設定が正しく適用されることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #163