### PR TITLE
feat: rootのdependabotをroot packageのみに制限

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,6 +23,13 @@ updates:
       timezone: Asia/Tokyo
     cooldown:
       default-days: 3
+    allow:
+      - dependency-name: "@biomejs/biome"
+      - dependency-name: "@textlint-ja/textlint-rule-preset-ai-writing"
+      - dependency-name: "lefthook"
+      - dependency-name: "textlint"
+      - dependency-name: "textlint-rule-preset-ja-technical-writing"
+      - dependency-name: "turbo"
   - package-ecosystem: npm
     directory: /graphql
     schedule:


### PR DESCRIPTION
## 概要

- rootディレクトリのdependabotにallow設定を追加し、rootのpackage.jsonに定義されているパッケージのみが更新対象となるように制限しました。これにより、サブディレクトリのパッケージが意図せず更新されることを防止できます。

## テスト計画

- [ ] dependabot.yamlのallow設定が正しく追加されていること
- [ ] rootのpackage.jsonに定義されている6つのパッケージのみが許可されていること

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #172