### PR TITLE
GraphQLのpre-pushでcodegen:checkを実行する仕組みを追加

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,7 +22,7 @@ pre-push:
       run: pnpm turbo test:changed --affected
     codegen-check:
       glob: "graphql/**/*.{ts,js,prisma,graphql}"
-      run: pnpm --filter mobile codegen:check
+      run: pnpm codegen:check
 
 pre-commit:
   parallel: true

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,7 +20,6 @@
     "vrt:approve": "pnpm storybook:capture && pnpm reg-cli ./vrt/public/report/actual ./vrt/public/report/expected ./vrt/public/report/diff -R ./vrt/public/report/index.html -J ./vrt/public/report/reg.json -T 0.0001 -U -E",
     "expo:fix": "expo install --fix",
     "codegen": "cp ../graphql/.pylon/schema.graphql src/libs/graphql/schema.graphql && graphql-codegen && pnpm typenames:generate",
-    "codegen:check": "cp ../graphql/.pylon/schema.graphql src/libs/graphql/schema.graphql && graphql-codegen --check",
     "typenames:generate": "tsx ./scripts/generate-typenames.ts",
     "licenses:generate": "node scripts/generate-licenses.mjs"
   },


### PR DESCRIPTION
## 概要

- GraphQLスキーマ変更時のコミット漏れによるCIエラーを防止するため、pre-pushフックでcodegen:checkを実行する仕組みを追加しました。

## テスト計画

- [ ] mobile/package.jsonにcodegen:checkスクリプトが正しく追加されていることを確認
- [ ] lefthook.ymlにcodegen-checkコマンドが追加されていることを確認
- [ ] GraphQL関連ファイル変更時にpre-pushでcodegen:checkが実行されることを確認
- [ ] GraphQL関連ファイル以外の変更時はcodegen:checkがスキップされることを確認

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #215