### PR TITLE
generate-typenamesをFragmentにも対応させる

### DIFF
--- a/mobile/src/libs/graphql/operationTypenames.generated.ts
+++ b/mobile/src/libs/graphql/operationTypenames.generated.ts
@@ -18,7 +18,8 @@ export const OPERATION_TYPENAMES = {
     "Tag"
   ],
   "GetBookmarksQuery": [
-    "Bookmark"
+    "Bookmark",
+    "Tag"
   ],
   "DeleteBookmarkMutation": []
 } as const;


### PR DESCRIPTION
## 概要

- Fragment参照(`$fragmentRefs`)を検出してFragment内の__typenameも抽出するよう修正しました。これによりGetBookmarksQueryでBookmarkFragmentのTag typenameが正しく認識されるようになりました。

## テスト計画

- [ ] generate-typenamesスクリプトが正常に実行されること
- [ ] GetBookmarksQueryで`["Bookmark", "Tag"]`が出力されること
- [ ] 既存のQuery/Mutationの__typename抽出が正常に動作すること
- [ ] リント・型チェックが通ること

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #221