### PR TITLE
Article APIをoffset based paginationに変更

### DIFF
--- a/graphql/src/application/articles/FetchArticlesUseCase.test.ts
+++ b/graphql/src/application/articles/FetchArticlesUseCase.test.ts
@@ -7,8 +7,9 @@ describe("FetchArticlesUseCase", () => {
   it("should return an array of articles", async () => {
     mockServer.use(...ArticleMocks.Success);
 
-    const page = 1;
-    const result = await fetchArticlesUseCase(page);
+    const offset = 0;
+    const limit = 20;
+    const result = await fetchArticlesUseCase(offset, limit);
 
     expect(result.length).toBeGreaterThan(0);
     for (const article of result) {

--- a/graphql/src/application/articles/FetchArticlesUseCase.ts
+++ b/graphql/src/application/articles/FetchArticlesUseCase.ts
@@ -3,10 +3,11 @@ import type { Article } from "../../infrastructure/domain/Article";
 import * as articleRepository from "../../infrastructure/external/ArticleRepository";
 
 export const fetchArticlesUseCase = async (
-  page: number,
+  offset = 0,
+  limit = 20,
 ): Promise<Article[]> => {
   try {
-    return await articleRepository.fetchArticles(page);
+    return await articleRepository.fetchArticles(offset, limit);
   } catch (error) {
     throw new ServiceError(
       `Failed to fetch articles: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/graphql/src/infrastructure/external/ArticleRepository.ts
+++ b/graphql/src/infrastructure/external/ArticleRepository.ts
@@ -1,28 +1,41 @@
 import { createQiitaApiClient } from "../../libs/openapi/client";
 import type { Article } from "../domain/Article";
 
-export const fetchArticles = async (page: number): Promise<Article[]> => {
+export const fetchArticles = async (
+  offset = 0,
+  limit = 20,
+): Promise<Article[]> => {
+  // Qiita API uses page-based pagination, so we need to convert offset/limit to page
+  const page = Math.floor(offset / limit) + 1;
+  const perPage = limit;
+
   const response = await createQiitaApiClient().GET("/items", {
     params: {
       query: {
         page,
+        per_page: perPage,
       },
     },
   });
-  return (
-    response.data?.map((item) => ({
-      id: item.id,
-      title: item.title,
-      body: item.body,
-      url: item.url,
-      user: {
-        name: item.user?.name,
-      },
-      tags: item.tags.map((tag) => ({
-        name: tag.name,
-      })),
-      created_at: item.created_at,
-      updated_at: item.updated_at,
-    })) || []
-  );
+
+  const items = response.data || [];
+
+  // Calculate the actual offset within the page
+  const pageOffset = offset % limit;
+
+  // Return the subset of items based on the actual offset and limit
+  return items.slice(pageOffset, pageOffset + limit).map((item) => ({
+    id: item.id,
+    title: item.title,
+    body: item.body,
+    url: item.url,
+    user: {
+      name: item.user?.name,
+    },
+    tags: item.tags.map((tag) => ({
+      name: tag.name,
+    })),
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+  }));
 };

--- a/graphql/src/server.test.ts
+++ b/graphql/src/server.test.ts
@@ -8,8 +8,9 @@ describe("GraphQL Resolvers", () => {
     describe("articles", () => {
       it("should return an array of articles", async () => {
         mockServer.use(...ArticleMocks.Success);
-        const page = 1;
-        const result = await server.Query.articles(page);
+        const offset = 0;
+        const limit = 20;
+        const result = await server.Query.articles(offset, limit);
 
         expect(result.length).toBeGreaterThan(0);
         for (const article of result) {

--- a/graphql/src/server.ts
+++ b/graphql/src/server.ts
@@ -18,7 +18,8 @@ import { fetchTagsUseCase } from "./application/tags/FetchTagsUseCase";
 
 export const server = {
   Query: {
-    articles: async (page: number) => await fetchArticlesUseCase(page),
+    articles: async (offset?: number, limit?: number) =>
+      await fetchArticlesUseCase(offset, limit),
     bookmarks: async () => await fetchBookmarksUseCase(),
     bookmark: async (id: string) => await fetchBookmarkByIdUseCase(id),
     tags: async () => await fetchTagsUseCase(),

--- a/mobile/src/features/Articles/index.tsx
+++ b/mobile/src/features/Articles/index.tsx
@@ -17,8 +17,8 @@ type Item = {
 };
 
 export const GetArticles = graphql(`
-  query GetArticles($page: Number!) {
-    articles(page: $page) {
+  query GetArticles($offset: Number, $limit: Number) {
+    articles(offset: $offset, limit: $limit) {
       __typename
       created_at
       id
@@ -36,7 +36,7 @@ export const GetArticles = graphql(`
 export const Articles: FC = () => {
   const [{ data }] = useSuspenseQuery({
     query: GetArticles,
-    variables: { page: 1 },
+    variables: { offset: 0, limit: 20 },
   });
 
   const renderItem = ({ item }: { item: Item }) => (

--- a/mobile/src/libs/graphql/schema.graphql
+++ b/mobile/src/libs/graphql/schema.graphql
@@ -14,7 +14,7 @@ input CreateTagInputInput {
   name: String!
 }
 type Query {
-  articles(page: Number!): [Article!]!
+  articles(offset: Number, limit: Number): [Article!]!
   bookmarks: [Bookmark!]!
   bookmark(id: String!): Bookmark
   tags: [Tag!]!


### PR DESCRIPTION
## 概要

- Article APIのページネーション処理を従来のpage-basedからoffset-basedなAPIに変更しました。この変更により、Apollo GraphQLの推奨するoffset-basedパターンに準拠し、より効率的でスケーラブルなページネーション処理が可能になります。

## テスト計画

- [ ] GraphQLスキーマが offset: Number, limit: Number を受け取ることを確認
- [ ] FetchArticlesUseCaseが正しくoffset/limitパラメータを処理することを確認
- [ ] ArticleRepositoryでQiita APIのpage-basedとoffset-basedの変換処理が動作することを確認
- [ ] モバイルクライアントでoffset/limitを使用してクエリが実行されることを確認
- [ ] 既存のテストが全て成功することを確認

## 補足事項

- Apollo GraphQLドキュメント（https://www.apollographql.com/docs/react/pagination/offset-based）を参考に実装
- QiitaAPIが使用するpage-basedとのブリッジロジックをArticleRepositoryで実装
- デフォルト値としてoffset=0, limit=20を設定

Fixes #232