### PR TITLE
feat: グローバルステート管理をjotaiに統一

### DIFF
--- a/mobile/src/libs/auth/AuthContext.test.tsx
+++ b/mobile/src/libs/auth/AuthContext.test.tsx
@@ -1,18 +1,17 @@
 import { act, renderHook } from "@testing-library/react-native";
 import type React from "react";
 import { AuthProvider, useAuth } from "./AuthContext";
-
-// updateAuthHeaders関数のモック
-jest.mock("@/libs/graphql/urql", () => ({
-  updateAuthHeaders: jest.fn(),
-}));
-
-import { updateAuthHeaders } from "@/libs/graphql/urql";
+import { resetAuthStore } from "./authStore";
 
 describe("AuthContext", () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <AuthProvider>{children}</AuthProvider>
   );
+
+  beforeEach(() => {
+    // 各テストの前にストアをリセット
+    resetAuthStore();
+  });
 
   describe("useAuth", () => {
     it("初期状態が正しく設定されている", () => {
@@ -35,8 +34,6 @@ describe("AuthContext", () => {
         testKey: "key456",
         isLoggedIn: true,
       });
-
-      expect(updateAuthHeaders).toHaveBeenCalledWith("user123", "key456");
     });
 
     it("logout関数が正しく動作する", async () => {
@@ -53,8 +50,6 @@ describe("AuthContext", () => {
         testKey: null,
         isLoggedIn: false,
       });
-
-      expect(updateAuthHeaders).toHaveBeenCalledWith(null, null);
     });
 
     it("testLogin関数が正しく動作する", async () => {
@@ -67,8 +62,6 @@ describe("AuthContext", () => {
         testKey: "test-key",
         isLoggedIn: true,
       });
-
-      expect(updateAuthHeaders).toHaveBeenCalledWith("test-user", "test-key");
     });
 
     it("複数回のログイン/ログアウトが正しく動作する", async () => {

--- a/mobile/src/libs/auth/AuthContext.tsx
+++ b/mobile/src/libs/auth/AuthContext.tsx
@@ -7,6 +7,7 @@ import {
   logoutAtom,
   testLoginAtom,
 } from "./authAtoms";
+import { initAuthStore } from "./authStore";
 
 interface AuthContextType {
   authState: AuthState;
@@ -20,7 +21,9 @@ interface AuthProviderProps {
 }
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
-  return <Provider>{children}</Provider>;
+  // グローバルストアを初期化してProviderに渡す
+  const store = initAuthStore();
+  return <Provider store={store}>{children}</Provider>;
 };
 
 export const useAuth = (): AuthContextType => {

--- a/mobile/src/libs/auth/authAtoms.test.ts
+++ b/mobile/src/libs/auth/authAtoms.test.ts
@@ -9,13 +9,6 @@ import {
   userIdAtom,
 } from "./authAtoms";
 
-// updateAuthHeaders関数のモック
-jest.mock("@/libs/graphql/urql", () => ({
-  updateAuthHeaders: jest.fn(),
-}));
-
-import { updateAuthHeaders } from "@/libs/graphql/urql";
-
 describe("authAtoms", () => {
   let store: ReturnType<typeof createStore>;
 
@@ -48,8 +41,6 @@ describe("authAtoms", () => {
         testKey,
         isLoggedIn: true,
       });
-
-      expect(updateAuthHeaders).toHaveBeenCalledWith(userId, testKey);
     });
   });
 
@@ -67,8 +58,6 @@ describe("authAtoms", () => {
         testKey: null,
         isLoggedIn: false,
       });
-
-      expect(updateAuthHeaders).toHaveBeenCalledWith(null, null);
     });
   });
 
@@ -82,8 +71,6 @@ describe("authAtoms", () => {
         testKey: "test-key",
         isLoggedIn: true,
       });
-
-      expect(updateAuthHeaders).toHaveBeenCalledWith("test-user", "test-key");
     });
   });
 

--- a/mobile/src/libs/auth/authAtoms.ts
+++ b/mobile/src/libs/auth/authAtoms.ts
@@ -1,5 +1,4 @@
 import { atom } from "jotai";
-import { updateAuthHeaders } from "@/libs/graphql/urql";
 
 export interface AuthState {
   userId: string | null;
@@ -26,16 +25,12 @@ export const loginAtom = atom(
       isLoggedIn: true,
     };
     set(authStateAtom, newState);
-    // GraphQLクライアントのヘッダーを更新
-    updateAuthHeaders(userId, testKey);
   },
 );
 
 // ログアウト処理を行うwrite-only atom
 export const logoutAtom = atom(null, (_get, set) => {
   set(authStateAtom, initialAuthState);
-  // GraphQLクライアントのヘッダーをクリア
-  updateAuthHeaders(null, null);
 });
 
 // テストログイン処理を行うwrite-only atom

--- a/mobile/src/libs/auth/authStore.ts
+++ b/mobile/src/libs/auth/authStore.ts
@@ -1,0 +1,36 @@
+import { createStore } from "jotai";
+
+// グローバルなjotaiストアを作成
+// このストアは認証状態を管理し、urqlClientなどからアクセス可能
+let globalAuthStore: ReturnType<typeof createStore> | null = null;
+
+/**
+ * 認証用のjotaiストアを初期化する
+ * アプリケーション起動時に一度だけ呼ばれる
+ */
+export const initAuthStore = () => {
+  if (!globalAuthStore) {
+    globalAuthStore = createStore();
+  }
+  return globalAuthStore;
+};
+
+/**
+ * 認証用のjotaiストアを取得する
+ * urqlClientのfetchOptionsなど、Reactコンポーネント外からアクセスする場合に使用
+ */
+export const getAuthStore = () => {
+  if (!globalAuthStore) {
+    // ストアが未初期化の場合は自動的に初期化
+    return initAuthStore();
+  }
+  return globalAuthStore;
+};
+
+/**
+ * テスト用にストアをリセットする
+ * @internal
+ */
+export const resetAuthStore = () => {
+  globalAuthStore = null;
+};

--- a/mobile/src/libs/graphql/urql.ts
+++ b/mobile/src/libs/graphql/urql.ts
@@ -1,32 +1,11 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: for urql wrapper */
 import { useCallback, useMemo, useState } from "react";
 import * as Urql from "urql";
+import { authStateAtom } from "@/libs/auth/authAtoms";
+import { getAuthStore } from "@/libs/auth/authStore";
 import { OPERATION_TYPENAMES } from "@/libs/graphql/operationTypenames.generated";
 
 export * from "urql";
-
-// グローバルな認証状態を管理する変数
-let globalAuthState: {
-  userId: string | null;
-  testKey: string | null;
-  isLoggedIn: boolean;
-} = {
-  userId: null,
-  testKey: null,
-  isLoggedIn: false,
-};
-
-// 認証状態を更新する関数
-export const updateAuthHeaders = (
-  userId: string | null,
-  testKey: string | null,
-) => {
-  globalAuthState = {
-    userId,
-    testKey,
-    isLoggedIn: !!(userId && testKey),
-  };
-};
 
 export const urqlClient = new Urql.Client({
   url: "http://127.0.0.1:3000/graphql",
@@ -37,12 +16,16 @@ export const urqlClient = new Urql.Client({
     const isDevelopmentOrTest = __DEV__ || process.env.NODE_ENV === "test";
 
     if (isDevelopmentOrTest) {
-      // グローバルな認証状態が設定されている場合はそれを使用、そうでなければデフォルト値
-      const userId = globalAuthState.isLoggedIn
-        ? (globalAuthState.userId ?? "test-user")
+      // jotaiストアから認証状態を取得
+      const store = getAuthStore();
+      const authState = store.get(authStateAtom);
+
+      // 認証状態が設定されている場合はそれを使用、そうでなければデフォルト値
+      const userId = authState.isLoggedIn
+        ? (authState.userId ?? "test-user")
         : "test-user";
-      const testKey = globalAuthState.isLoggedIn
-        ? (globalAuthState.testKey ?? "test-key")
+      const testKey = authState.isLoggedIn
+        ? (authState.testKey ?? "test-key")
         : "test-key";
 
       return {


### PR DESCRIPTION
## 概要

- ContextProviderと独自のグローバルステート管理をjotaiに統一し、状態管理を一元化しました。これにより、コードの可読性と保守性が向上しました。

## テスト計画

- [ ] 認証状態がjotaiストアで正しく管理されること
- [ ] urqlClientがjotaiストアから認証情報を取得できること
- [ ] 既存の全テストが正常に通過すること
- [ ] 型チェックが正常に通過すること

## 補足事項

<!-- Pull Request を実装するために参考にした情報など -->

Fixes #288